### PR TITLE
feat: announcer-jammers view — per-jammer stats, lap scores, star pass detection + auto-playing demo

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'demo/**'
       - 'html/custom/view/announcer-jammers*'
+
+  # Allow manual trigger from Actions tab
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ html/custom
 !html/custom/view/announcer-stats.html
 !html/custom/view/announcer-stats.css
 !html/custom/view/announcer-stats.js
+!html/custom/view/announcer-jammers.html
+!html/custom/view/announcer-jammers.css
+!html/custom/view/announcer-jammers-render.js
 html/themes/custom
 GameData
 android/.gradle/

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Announcer Jammers — Demo</title>
+
+    <!-- Load jQuery from CDN for the standalone demo -->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+
+    <!-- Load mock WS (defines WS, startGameScenario, resetScenario) -->
+    <script src="mock-ws.js"></script>
+
+    <!-- Load shared render logic (uses WS.*, populates #game-stats, #jammer-table-N) -->
+    <script src="../html/custom/view/announcer-jammers-render.js"></script>
+
+    <link rel="stylesheet" href="../html/custom/view/announcer-jammers.css">
+  </head>
+  <body class="preload">
+    <div class="announcer-jammers">
+
+      <!-- Demo Status Bar -->
+      <div id="connection-status" class="connection-status" style="display:flex;align-items:center;justify-content:space-between">
+        <span>🎯 Demo Mode</span>
+        <span>
+          <button id="btn-start" class="demo-btn">▶ Start Demo Game</button>
+          <button id="btn-reset" class="demo-btn demo-btn-secondary" style="display:none">⟳ Reset</button>
+        </span>
+      </div>
+
+      <!-- Game Stats Header -->
+      <div id="game-stats" class="game-stats-header">
+        <div class="empty-message">Click "Start Demo Game" to begin…</div>
+      </div>
+
+      <!-- Team 1 Section -->
+      <section class="team-section">
+        <div class="team-header" id="team-header-1">
+          <span class="team-name" id="team-name-1">Thunderbirds</span>
+          <span class="team-score-display">Score: <strong id="team-score-1">0</strong></span>
+        </div>
+        <div class="team-table-wrapper">
+          <div id="jammer-table-1">
+            <div class="empty-message">Click "Start Demo Game" to begin…</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Team 2 Section -->
+      <section class="team-section">
+        <div class="team-header" id="team-header-2">
+          <span class="team-name" id="team-name-2">Valkyries</span>
+          <span class="team-score-display">Score: <strong id="team-score-2">0</strong></span>
+        </div>
+        <div class="team-table-wrapper">
+          <div id="jammer-table-2">
+            <div class="empty-message">Click "Start Demo Game" to begin…</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <!-- Demo Controls -->
+    <style>
+      .demo-btn {
+        background: #238636;
+        color: #fff;
+        border: 1px solid rgba(240,246,252,0.1);
+        border-radius: 6px;
+        padding: 4px 12px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s ease;
+      }
+      .demo-btn:hover {
+        background: #2ea043;
+      }
+      .demo-btn:active {
+        background: #238636;
+      }
+      .demo-btn-secondary {
+        background: #21262d;
+        color: #c9d1d9;
+        border-color: #30363d;
+      }
+      .demo-btn-secondary:hover {
+        background: #30363d;
+      }
+    </style>
+
+    <script>
+      (function () {
+        'use strict';
+
+        var btnStart = document.getElementById('btn-start');
+        var btnReset = document.getElementById('btn-reset');
+
+        btnStart.addEventListener('click', function () {
+          // Reset any previous state
+          if (typeof resetScenario === 'function') resetScenario();
+          // Populate mock state with initial teams + skaters then render
+          WS._fireAfterLoad();
+          // Start the game scenario
+          startGameScenario();
+          btnStart.textContent = '▶ Running…';
+          btnStart.disabled = true;
+          btnReset.style.display = 'inline';
+        });
+
+        btnReset.addEventListener('click', function () {
+          if (typeof resetScenario === 'function') resetScenario();
+          // Re-render to show empty state
+          var emptyEls = document.querySelectorAll('.empty-message');
+          if (emptyEls.length > 0) {
+            document.getElementById('game-stats').innerHTML =
+              '<div class="empty-message">Click "Start Demo Game" to begin…</div>';
+            document.getElementById('jammer-table-1').innerHTML =
+              '<div class="empty-message">Click "Start Demo Game" to begin…</div>';
+            document.getElementById('jammer-table-2').innerHTML =
+              '<div class="empty-message">Click "Start Demo Game" to begin…</div>';
+          }
+          btnStart.textContent = '▶ Start Demo Game';
+          btnStart.disabled = false;
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Announcer Jammers View — Demo</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+
+      body {
+        background: #0d1117;
+        color: #e6edf3;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        text-align: center;
+      }
+
+      .landing {
+        max-width: 560px;
+        padding: 40px 24px;
+      }
+
+      .logo {
+        font-size: 48px;
+        margin-bottom: 16px;
+      }
+
+      h1 {
+        font-size: 28px;
+        font-weight: 700;
+        margin-bottom: 8px;
+        letter-spacing: -0.5px;
+      }
+
+      .subtitle {
+        color: #8b949e;
+        font-size: 16px;
+        margin-bottom: 32px;
+        line-height: 1.5;
+      }
+
+      .feature-list {
+        text-align: left;
+        background: #161b22;
+        border: 1px solid #30363d;
+        border-radius: 8px;
+        padding: 20px 24px;
+        margin-bottom: 32px;
+      }
+
+      .feature-list h3 {
+        font-size: 14px;
+        color: #8b949e;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 12px;
+      }
+
+      .feature-list ul {
+        list-style: none;
+        padding: 0;
+      }
+
+      .feature-list li {
+        padding: 6px 0;
+        font-size: 14px;
+        line-height: 1.5;
+        color: #c9d1d9;
+      }
+
+      .feature-list li::before {
+        content: '▸ ';
+        color: #58a6ff;
+      }
+
+      .btn-start {
+        display: inline-block;
+        background: #238636;
+        color: #ffffff;
+        border: none;
+        border-radius: 8px;
+        padding: 14px 40px;
+        font-size: 18px;
+        font-weight: 700;
+        cursor: pointer;
+        text-decoration: none;
+        transition: background 0.15s ease, transform 0.1s ease;
+      }
+
+      .btn-start:hover {
+        background: #2ea043;
+        transform: translateY(-1px);
+      }
+
+      .btn-start:active {
+        transform: translateY(0);
+      }
+
+      .footer {
+        margin-top: 32px;
+        font-size: 12px;
+        color: #484f58;
+      }
+
+      .footer a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .footer a:hover {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="landing">
+
+      <div class="logo">🎯</div>
+
+      <h1>Announcer Jammers View</h1>
+      <p class="subtitle">
+        A live jammer-performance dashboard for roller derby announcers.<br>
+        Real-time stats, scoring pass breakdowns, and team comparisons —<br>
+        designed for game day.
+      </p>
+
+      <div class="feature-list">
+        <h3>What you'll see</h3>
+        <ul>
+          <li>Per-jammer stats: lap scores, jams played, lead %, total score, PPJ, team contribution</li>
+          <li>Game stats header: lead %, lead count, score, points-per-jam, ratio</li>
+          <li>Star pass detection with visual differentiation</li>
+          <li>Live reactive updates as the game progresses</li>
+          <li>Dark theme — ready for the announcer booth</li>
+        </ul>
+      </div>
+
+      <a href="demo.html" class="btn-start">▶ Start Demo</a>
+
+      <p class="footer">
+        Custom view for <a href="https://github.com/rollerderby/scoreboard" target="_blank">CRG ScoreBoard</a>
+      </p>
+
+    </div>
+  </body>
+</html>

--- a/demo/mock-ws.js
+++ b/demo/mock-ws.js
@@ -1,0 +1,446 @@
+/**
+ * mock-ws.js — Fake WebSocket engine for the Announcer Jammers Demo
+ *
+ * Implements the same API surface as CRG ScoreBoard's core.js:
+ *   - WS.state (flat key-value object)
+ *   - WS.Register(paths, callback)
+ *   - WS.AfterLoad(callback)
+ *   - WS.Set(path, value)
+ *
+ * Also provides:
+ *   - startGameScenario() — begins the scripted game
+ *   - resetScenario() — resets all state for replay
+ */
+
+(function () {
+  'use strict';
+
+  /* ── Mock WS Object ── */
+
+  window.WS = {
+    state: {},
+    _callbacks: [],
+    _afterLoad: [],
+    _loaded: false,
+
+    Register: function (paths, cb) {
+      if (typeof paths === 'string') paths = [paths];
+      if (cb) {
+        this._callbacks.push({ paths: paths, cb: cb });
+      }
+    },
+
+    Set: function (path, val) {
+      this.state[path] = val;
+      // Fire relevant callbacks
+      var self = this;
+      this._callbacks.forEach(function (entry) {
+        entry.paths.forEach(function (p) {
+          // Simple wildcard match — (*) matches any single segment
+          var pattern = p
+            .replace(/\./g, '\\.')
+            .replace(/\(\*\)/g, '([^)]+)')
+            .replace(/\(\\\*\)/g, '(.+)');
+          var re = new RegExp('^' + pattern + '$');
+          if (re.test(path)) {
+            try { entry.cb(); } catch (e) { /* swallow render errors */ }
+            return;
+          }
+        });
+      });
+    },
+
+    AfterLoad: function (cb) {
+      if (this._loaded) {
+        setTimeout(cb, 0);
+      } else {
+        this._afterLoad.push(cb);
+      }
+    },
+
+    _fireAfterLoad: function () {
+      this._loaded = true;
+      var self = this;
+      this._afterLoad.forEach(function (cb) {
+        setTimeout(cb, 0);
+      });
+    }
+  };
+
+  // Helper for isTrue (some render code uses global isTrue)
+  window.isTrue = function (v) {
+    return v === true || v === 'true' || v === 1 || v === '1';
+  };
+
+  // Time conversions (some render code references _timeConversions)
+  window._timeConversions = {
+    msToMinSec: function (ms) {
+      var totalSec = Math.max(0, Math.floor((parseInt(ms, 10) || 0) / 1000));
+      var m = Math.floor(totalSec / 60);
+      var s = totalSec % 60;
+      return m + ':' + (s < 10 ? '0' : '') + s;
+    }
+  };
+
+  /* ═══════════════════════════════════════════
+   *  Scripted Game Scenario
+   * ═══════════════════════════════════════════ */
+
+  var PREFIX = 'ScoreBoard.CurrentGame';
+  var _timer = null;
+  var _currentStep = -1;
+  var _running = false;
+
+  // Skater definitions
+  var TEAM1_SKATERS = [
+    { name: 'Bones', number: '420' },
+    { name: 'Smash', number: '777' },
+    { name: 'Blitz', number: '99' }
+  ];
+  var TEAM2_SKATERS = [
+    { name: 'Viper', number: '13' },
+    { name: 'Fury', number: '8' },
+    { name: 'Blade', number: '42' }
+  ];
+
+  // Scripted jams: each jam has team1 and team2 data
+  // scoringTrips are per-scoring-pass points
+  // starPass: if true, starting jammer passes to a different skater
+  var SCRIPTED_JAMS = [
+    {
+      team1: { jammer: 0, leading: true, scoringTrips: [4, 3] },
+      team2: { jammer: 3, leading: false, scoringTrips: [1] }
+    },
+    {
+      team1: { jammer: 0, leading: false, scoringTrips: [1] },
+      team2: { jammer: 3, leading: true, scoringTrips: [3, 2, 2] }
+    },
+    {
+      team1: { jammer: 1, leading: true, scoringTrips: [3, 1] },
+      team2: { jammer: 4, leading: false, scoringTrips: [2] }
+    },
+    {
+      team1: { jammer: 0, leading: true, scoringTrips: [5] },
+      team2: { jammer: 3, leading: false, scoringTrips: [] }
+    },
+    {
+      team1: { jammer: 1, leading: false, scoringTrips: [] },
+      team2: { jammer: 4, leading: true, scoringTrips: [4, 1, 1] }
+    },
+    {
+      team1: { jammer: 0, leading: true, scoringTrips: [2, 2, 1] },
+      team2: { jammer: 3, leading: false, scoringTrips: [1] }
+    },
+    {
+      team1: { jammer: 0, leading: false, scoringTrips: [1] },
+      team2: { jammer: 5, leading: true, scoringTrips: [3] }
+    },
+    {
+      // Star pass: "Blitz" (#99) receives star pass from "Smash" (#777)
+      team1: { jammer: 1, leading: true, scoringTrips: [3], starPassTo: 2, afterSPTrips: [2] },
+      team2: { jammer: 4, leading: false, scoringTrips: [1] }
+    },
+    {
+      team1: { jammer: 0, leading: true, scoringTrips: [4, 2] },
+      team2: { jammer: 3, leading: false, scoringTrips: [] }
+    },
+    {
+      team1: { jammer: 2, leading: false, scoringTrips: [2] },
+      team2: { jammer: 5, leading: true, scoringTrips: [5] }
+    },
+    {
+      team1: { jammer: 0, leading: true, scoringTrips: [3, 3] },
+      team2: { jammer: 4, leading: false, scoringTrips: [2, 1] }
+    },
+    {
+      team1: { jammer: 1, leading: false, scoringTrips: [] },
+      team2: { jammer: 3, leading: true, scoringTrips: [4, 2, 1] }
+    }
+  ];
+
+  /**
+   * Reset WS.state to initial (empty game with teams set).
+   */
+  function resetState() {
+    var s = WS.state;
+
+    // Clear everything
+    Object.keys(s).forEach(function (k) { delete s[k]; });
+
+    // Team 1
+    s[PREFIX + '.Team(1).Name'] = 'Thunderbirds';
+    s[PREFIX + '.Team(1).AlternateName(operator)'] = 'THUNDER';
+    s[PREFIX + '.Team(1).Score'] = '0';
+    s[PREFIX + '.Team(1).JamScore'] = '0';
+    s[PREFIX + '.Team(1).Timeouts'] = '3';
+    s[PREFIX + '.Team(1).OfficialReviews'] = '2';
+    s[PREFIX + '.Team(1).TotalPenalties'] = '0';
+    s[PREFIX + '.Team(1).Color(overlay.bg)'] = '#1f6feb';
+    s[PREFIX + '.Team(1).Color(overlay.fg)'] = '#ffffff';
+
+    // Team 2
+    s[PREFIX + '.Team(2).Name'] = 'Valkyries';
+    s[PREFIX + '.Team(2).AlternateName(operator)'] = 'VALKYRIE';
+    s[PREFIX + '.Team(2).Score'] = '0';
+    s[PREFIX + '.Team(2).JamScore'] = '0';
+    s[PREFIX + '.Team(2).Timeouts'] = '3';
+    s[PREFIX + '.Team(2).OfficialReviews'] = '2';
+    s[PREFIX + '.Team(2).TotalPenalties'] = '0';
+    s[PREFIX + '.Team(2).Color(overlay.bg)'] = '#da3633';
+    s[PREFIX + '.Team(2).Color(overlay.fg)'] = '#ffffff';
+
+    // Skaters
+    TEAM1_SKATERS.forEach(function (sk, i) {
+      s[PREFIX + '.Team(1).Skater(' + i + ').Name'] = sk.name;
+      s[PREFIX + '.Team(1).Skater(' + i + ').RosterNumber'] = sk.number;
+    });
+    TEAM2_SKATERS.forEach(function (sk, i) {
+      var idx = i + TEAM1_SKATERS.length; // 3, 4, 5
+      s[PREFIX + '.Team(2).Skater(' + idx + ').Name'] = sk.name;
+      s[PREFIX + '.Team(2).Skater(' + idx + ').RosterNumber'] = sk.number;
+    });
+
+    // Initial clock state — pre-game
+    s[PREFIX + '.InJam'] = 'false';
+    s[PREFIX + '.Clock(Period).Time'] = '1800000';
+    s[PREFIX + '.Clock(Jam).Time'] = '120000';
+    s[PREFIX + '.Clock(Timeout).Running'] = 'false';
+    s[PREFIX + '.Clock(Lineup).Running'] = 'true';
+    s[PREFIX + '.Clock(Intermission).Running'] = 'false';
+    s[PREFIX + '.Clock(Intermission).Number'] = '0';
+    s[PREFIX + '.OfficialScore'] = 'false';
+    s[PREFIX + '.ClockDuringFinalScore'] = 'false';
+    s[PREFIX + '.TimeoutOwner'] = '';
+    s[PREFIX + '.OfficialReview'] = 'false';
+    s[PREFIX + '.Rule(Period.Number)'] = '1';
+  }
+
+  /**
+   * Apply a jam's data to WS.state.
+   */
+  function applyJam(jamIdx, jamData) {
+    var s = WS.state;
+    var period = 1;
+    var jam = jamIdx + 1; // 1-indexed
+
+    // Period time ticks down
+    var periodTime = 1800000 - (jamIdx * 90000);
+    s[PREFIX + '.Clock(Period).Time'] = String(Math.max(periodTime, 0));
+    s[PREFIX + '.Rule(Period.Number)'] = jam > 7 ? '2' : '1';
+
+    if (jam > 7) {
+      period = 2;
+      jam = jam - 7;
+      periodTime = 1800000 - ((jamIdx - 7) * 90000);
+      s[PREFIX + '.Clock(Period).Time'] = String(Math.max(periodTime, 0));
+    }
+
+    // ── Phase: Lineup ──
+    s[PREFIX + '.InJam'] = 'false';
+    s[PREFIX + '.Clock(Jam).Time'] = '120000';
+    s[PREFIX + '.Clock(Lineup).Running'] = 'true';
+    s[PREFIX + '.Clock(Intermission).Running'] = 'false';
+    s[PREFIX + '.Clock(Timeout).Running'] = 'false';
+
+    // Set team jam scores to 0 for this jam
+    s[PREFIX + '.Team(1).JamScore'] = '0';
+    s[PREFIX + '.Team(2).JamScore'] = '0';
+
+    // Calculate team total scores so far
+    var t1Total = 0;
+    var t2Total = 0;
+    for (var i = 0; i < jamIdx; i++) {
+      var prevJam = SCRIPTED_JAMS[i];
+      if (prevJam.team1 && prevJam.team1.scoringTrips) {
+        prevJam.team1.scoringTrips.forEach(function (p) { t1Total += p; });
+        if (prevJam.team1.afterSPTrips) {
+          prevJam.team1.afterSPTrips.forEach(function (p) { t1Total += p; });
+        }
+      }
+      if (prevJam.team2 && prevJam.team2.scoringTrips) {
+        prevJam.team2.scoringTrips.forEach(function (p) { t2Total += p; });
+      }
+    }
+
+    // ── Set fielding and team jam data for this jam ──
+
+    // Team 1 fielding
+    var t1JammerIdx = jamData.team1.jammer;
+    var t1JammerRef = 'Skater(' + t1JammerIdx + ')';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(0).Skater'] = t1JammerRef;
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(0).SkaterNumber'] = TEAM1_SKATERS[t1JammerIdx].number;
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(0).Position'] = 'Jammer';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(0).NotFielded'] = 'false';
+
+    // Team 2 fielding
+    var t2JammerIdx = jamData.team2.jammer;
+    // Map global skater index (3,4,5) to local TEAM2_SKATERS index (0,1,2)
+    var t2LocalIdx = t2JammerIdx - TEAM1_SKATERS.length;
+    var t2JammerRef = 'Skater(' + t2JammerIdx + ')';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Fielding(0).Skater'] = t2JammerRef;
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Fielding(0).SkaterNumber'] = TEAM2_SKATERS[t2LocalIdx].number;
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Fielding(0).Position'] = 'Jammer';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Fielding(0).NotFielded'] = 'false';
+
+    // Team 1 TeamJam fields
+    var t1JamScore = 0;
+    if (jamData.team1.scoringTrips) {
+      jamData.team1.scoringTrips.forEach(function (p) { t1JamScore += p; });
+    }
+    if (jamData.team1.afterSPTrips) {
+      jamData.team1.afterSPTrips.forEach(function (p) { t1JamScore += p; });
+    }
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).JamScore'] = String(t1JamScore);
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Lead'] = jamData.team1.leading ? 'true' : 'false';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Lost'] = (!jamData.team1.leading && t1JamScore > 0) ? 'true' : 'false';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).StarPass'] = jamData.team1.starPassTo !== undefined ? 'true' : 'false';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).TotalScore'] = String(t1Total);
+
+    // Scoring trips — Team 1
+    if (jamData.team1.scoringTrips) {
+      jamData.team1.scoringTrips.forEach(function (pts, idx) {
+        s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).ScoringTrip(' + idx + ').Score'] = String(pts);
+        s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).ScoringTrip(' + idx + ').AfterSP'] = 'false';
+      });
+    }
+    if (jamData.team1.afterSPTrips) {
+      var baseIdx = (jamData.team1.scoringTrips || []).length;
+      jamData.team1.afterSPTrips.forEach(function (pts, idx) {
+        s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).ScoringTrip(' + (baseIdx + idx) + ').Score'] = String(pts);
+        s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).ScoringTrip(' + (baseIdx + idx) + ').AfterSP'] = 'true';
+      });
+    }
+
+    // Star pass recipient fielding — Team 1
+    if (jamData.team1.starPassTo !== undefined) {
+      s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(1).Skater'] = 'Skater(' + jamData.team1.starPassTo + ')';
+      s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(1).SkaterNumber'] = TEAM1_SKATERS[jamData.team1.starPassTo].number;
+      s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Fielding(1).Position'] = 'Jammer';
+    }
+
+    // Team 2 TeamJam fields
+    var t2JamScore = 0;
+    if (jamData.team2.scoringTrips) {
+      jamData.team2.scoringTrips.forEach(function (p) { t2JamScore += p; });
+    }
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).JamScore'] = String(t2JamScore);
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Lead'] = jamData.team2.leading ? 'true' : 'false';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Lost'] = (!jamData.team2.leading && t2JamScore > 0) ? 'true' : 'false';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).StarPass'] = 'false';
+    s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).TotalScore'] = String(t2Total);
+
+    // Scoring trips — Team 2
+    if (jamData.team2.scoringTrips) {
+      jamData.team2.scoringTrips.forEach(function (pts, idx) {
+        s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).ScoringTrip(' + idx + ').Score'] = String(pts);
+        s[PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).ScoringTrip(' + idx + ').AfterSP'] = 'false';
+      });
+    }
+
+    // ── Update team total scores ──
+    t1Total += t1JamScore;
+    t2Total += t2JamScore;
+    s[PREFIX + '.Team(1).Score'] = String(t1Total);
+    s[PREFIX + '.Team(2).Score'] = String(t2Total);
+    s[PREFIX + '.Team(1).JamScore'] = String(t1JamScore);
+    s[PREFIX + '.Team(2).JamScore'] = String(t2JamScore);
+
+    // ── Phase: In Jam ──
+    s[PREFIX + '.InJam'] = 'true';
+    s[PREFIX + '.Clock(Jam).Time'] = '75000';
+    s[PREFIX + '.Clock(Lineup).Running'] = 'false';
+
+    // Fire WS.Set for the currently changed paths to trigger callbacks
+    // We fire a batch of key paths
+    var pathsToFire = [
+      PREFIX + '.InJam',
+      PREFIX + '.Team(1).Score',
+      PREFIX + '.Team(2).Score',
+      PREFIX + '.Team(1).JamScore',
+      PREFIX + '.Team(2).JamScore',
+      PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).JamScore',
+      PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).JamScore',
+      PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(1).Lead',
+      PREFIX + '.Period(' + period + ').Jam(' + jam + ').TeamJam(2).Lead'
+    ];
+    pathsToFire.forEach(function (p) {
+      // Use WS.Set to trigger callbacks
+      var val = s[p];
+      if (val !== undefined) {
+        // Directly invoke the Set logic
+        WS._callbacks.forEach(function (entry) {
+          entry.paths.forEach(function (pattern) {
+            var reStr = pattern
+              .replace(/\./g, '\\.')
+              .replace(/\(\*\)/g, '([^)]+)');
+            var re = new RegExp('^' + reStr + '$');
+            if (re.test(p)) {
+              try { entry.cb(); } catch (e) { /* swallow */ }
+            }
+          });
+        });
+      }
+    });
+
+    // Force full render after each jam via the exposed global
+    if (typeof window._announcerJammersRender === 'function') {
+      try { window._announcerJammersRender(); } catch (e) { /* swallow */ }
+    }
+  }
+
+  /**
+   * Start the scripted game scenario.
+   */
+  function startGameScenario() {
+    if (_running) return;
+    _running = true;
+    _currentStep = -1;
+
+    resetState();
+
+    // Fire AfterLoad
+    WS._fireAfterLoad();
+
+    // Progress through jams with delays
+    var stepDelay = 4500; // ms between each jam
+    var introDelay = 2500; // ms before first jam
+
+    _currentStep = -1;
+
+    function nextStep() {
+      _currentStep++;
+      if (_currentStep >= SCRIPTED_JAMS.length) {
+        // Game over — all jams played
+        _running = false;
+        return;
+      }
+
+      applyJam(_currentStep, SCRIPTED_JAMS[_currentStep]);
+
+      _timer = setTimeout(nextStep, stepDelay);
+    }
+
+    _timer = setTimeout(nextStep, introDelay);
+  }
+
+  /**
+   * Reset and stop.
+   */
+  function resetScenario() {
+    if (_timer) {
+      clearTimeout(_timer);
+      _timer = null;
+    }
+    _running = false;
+    _currentStep = -1;
+    resetState();
+    if (typeof fullRender === 'function') {
+      try { fullRender(); } catch (e) { /* swallow */ }
+    }
+  }
+
+  // Expose scenario controls
+  window.startGameScenario = startGameScenario;
+  window.resetScenario = resetScenario;
+
+})();

--- a/html/custom/view/announcer-jammers-render.js
+++ b/html/custom/view/announcer-jammers-render.js
@@ -1,0 +1,500 @@
+(function () {
+  'use strict';
+
+  /* ═══════════════════════════════════════════
+   * Announcer Jammers View — Shared Render Logic
+   *
+   * Dropped into CRG ScoreBoard as a custom view:
+   *   html/custom/view/announcer-jammers-render.js
+   *
+   * Also loaded by the standalone demo page with
+   * a mock WS object matching the same API surface.
+   * ═══════════════════════════════════════════ */
+
+  var PREFIX = 'ScoreBoard.CurrentGame';
+
+  /* ── Helpers ── */
+
+  function asNum(v) {
+    var n = parseInt(v, 10);
+    return isNaN(n) ? 0 : n;
+  }
+
+  function isTrue(v) {
+    return v === true || v === 'true' || v === 1 || v === '1';
+  }
+
+  function escHtml(s) {
+    if (!s) return '';
+    var d = document.createElement('div');
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  function round1(v) {
+    return (Math.round(v * 10) / 10).toFixed(1);
+  }
+
+  function getPath(suffix) {
+    return WS.state[PREFIX + '.' + suffix];
+  }
+
+  /* ═══════════════════════════════════════════
+   *  Data Extraction
+   * ═══════════════════════════════════════════ */
+
+  /**
+   * Collect all TeamJam data from WS.state into a structured array.
+   */
+  function collectTeamJams() {
+    var jams = {};
+    var re = new RegExp(
+      '^' + PREFIX.replace(/\./g, '\\.') +
+      '\\.Period\\((\\d+)\\)\\.Jam\\((\\d+)\\)\\.TeamJam\\((\\d+)\\)\\.(.+)$'
+    );
+
+    Object.keys(WS.state).forEach(function (key) {
+      var m = key.match(re);
+      if (!m) return;
+      var period = parseInt(m[1], 10);
+      var jam = parseInt(m[2], 10);
+      var team = m[3];
+      var rest = m[4];
+      var jamKey = period + '-' + jam;
+      if (!jams[jamKey]) {
+        jams[jamKey] = {
+          period: period,
+          jam: jam,
+          teams: {
+            '1': {},
+            '2': {}
+          }
+        };
+      }
+      var tj = jams[jamKey].teams[team];
+      if (!tj) return;
+
+      // Parse remaining path — could be nested (e.g. Fielding(0).Skater)
+      var parts = rest.match(/^(\w+)\((\d+)\)\.(\w+)$/);
+      if (parts) {
+        var childType = parts[1]; // Fielding or ScoringTrip
+        var childIdx = parts[2];
+        var childField = parts[3];
+        if (!tj[childType]) tj[childType] = {};
+        if (!tj[childType][childIdx]) tj[childType][childIdx] = {};
+        tj[childType][childIdx][childField] = WS.state[key];
+        return;
+      }
+
+      // Direct field (JamScore, Lead, Lost, StarPass, Calloff, TotalScore)
+      var directFields = ['JamScore', 'Lead', 'Lost', 'StarPass', 'Calloff', 'TotalScore'];
+      if (directFields.indexOf(rest) !== -1) {
+        tj[rest] = WS.state[key];
+      }
+    });
+
+    // Convert to sorted array
+    var result = [];
+    Object.keys(jams).forEach(function (k) { result.push(jams[k]); });
+    result.sort(function (a, b) {
+      if (a.period !== b.period) return a.period - b.period;
+      return a.jam - b.jam;
+    });
+    return result;
+  }
+
+  /**
+   * Build a skater lookup map from Team(N).Skater(*) data.
+   * Returns { skaterRef: { name, number, teamNum } }
+   */
+  function buildSkaterMap() {
+    var map = {};
+    var re = new RegExp(
+      '^' + PREFIX.replace(/\./g, '\\.') +
+      '\\.Team\\((\\d+)\\)\\.Skater\\((\\d+)\\)\\.(Name|RosterNumber)$'
+    );
+    Object.keys(WS.state).forEach(function (key) {
+      var m = key.match(re);
+      if (!m) return;
+      var teamNum = m[1];
+      var idx = m[2];
+      var field = m[3];
+      var ref = 'Skater(' + idx + ')';
+      if (!map[ref]) map[ref] = { name: null, number: null, teamNum: teamNum };
+      map[ref][field === 'Name' ? 'name' : 'number'] = WS.state[key];
+    });
+    return map;
+  }
+
+  /**
+   * Resolve a skater reference (e.g. "Skater(3)") to { name, number }.
+   */
+  function resolveSkater(ref, skaterMap) {
+    if (!ref) return { name: 'Unknown', number: '?' };
+    ref = ref.trim();
+    if (ref.indexOf('Skater(') === 0) {
+      var s = skaterMap[ref];
+      if (s) return { name: s.name || ref, number: s.number || '?' };
+    }
+    return { name: ref, number: '?' };
+  }
+
+  /**
+   * Compute all per-jammer stats and per-team game stats.
+   */
+  function computeAllStats() {
+    var teamJams = collectTeamJams();
+    var skaterMap = buildSkaterMap();
+
+    // Per-jammer accumulator: key = "teamNum:skaterRef"
+    var jammers = {};
+    // Per-team counters
+    var teamStats = {
+      '1': { leadCount: 0, totalScore: 0, totalJams: 0 },
+      '2': { leadCount: 0, totalScore: 0, totalJams: 0 }
+    };
+    var totalJamsCount = 0;
+
+    function getJammerKey(teamNum, skaterRef) {
+      return teamNum + ':' + (skaterRef || '').trim();
+    }
+
+    function ensureJammer(teamNum, skaterRef, skaterInfo) {
+      var key = getJammerKey(teamNum, skaterRef);
+      if (!jammers[key]) {
+        jammers[key] = {
+          teamNum: parseInt(teamNum, 10),
+          skaterRef: (skaterRef || '').trim(),
+          name: skaterInfo ? skaterInfo.name : 'Unknown',
+          number: skaterInfo ? skaterInfo.number : '?',
+          jamsTotal: 0,        // all jams as jammer (start + star-pass)
+          jamsStarted: 0,      // jams started as first jammer
+          jamsSP: 0,           // jams where they received star pass
+          leadCount: 0,
+          totalScore: 0,
+          lapScores: []        // array of per-scoring-pass values (flattened across jams)
+        };
+      }
+      return jammers[key];
+    }
+
+    // Iterate each jam
+    teamJams.forEach(function (jam) {
+      totalJamsCount++;
+      [1, 2].forEach(function (teamNum) {
+        var tj = jam.teams[teamNum];
+        if (!tj) return;
+
+        var tn = String(teamNum);
+        var jamScore = asNum(tj.JamScore);
+        var isLead = isTrue(tj.Lead);
+        var starPass = isTrue(tj.StarPass);
+
+        // Update team stats
+        teamStats[tn].totalScore += jamScore;
+        teamStats[tn].totalJams++;
+        if (isLead) teamStats[tn].leadCount++;
+
+        // Find jammer(s)
+        // Fielding entries are indexed: Fielding(0).Skater, Fielding(1).Skater, etc.
+        // Each has: Skater, SkaterNumber, Position
+        var fielding = tj.Fielding || {};
+        var fieldingKeys = Object.keys(fielding).sort();
+
+        // Find skaters who were jammer (first fielding at Jammer position is starting jammer)
+        var jammerRefs = [];
+
+        // Primary approach: iterate fieldings and look for Skater entries
+        fieldingKeys.forEach(function (idx) {
+          var f = fielding[idx];
+          if (f.Skater && f.Skater.trim()) {
+            // Record this skater as a jammer
+            jammerRefs.push(f.Skater.trim());
+          }
+        });
+
+        // If no fielding data found, try the legacy pattern
+        if (jammerRefs.length === 0) {
+          // Check for Fielding(Jammer).Skater pattern in WS.state directly
+          var legacyKey = PREFIX + '.Period(' + jam.period + ').Jam(' + jam.jam + ').TeamJam(' + teamNum + ').Fielding(Jammer).Skater';
+          var legacyRef = WS.state[legacyKey];
+          if (legacyRef && legacyRef.trim()) {
+            jammerRefs.push(legacyRef.trim());
+          }
+        }
+
+        if (jammerRefs.length === 0) return; // No jammer data yet
+
+        // First ref is starting jammer
+        var startRef = jammerRefs[0];
+        var startInfo = resolveSkater(startRef, skaterMap);
+
+        // Collect scoring trips
+        var scoringTrips = tj.ScoringTrip || {};
+        var tripKeys = Object.keys(scoringTrips).sort(function (a, b) {
+          return parseInt(a, 10) - parseInt(b, 10);
+        });
+
+        var preSPTrips = [];
+        var postSPTrips = [];
+
+        tripKeys.forEach(function (idx) {
+          var trip = scoringTrips[idx];
+          var score = asNum(trip.Score);
+          var afterSP = isTrue(trip.AfterSP);
+          if (afterSP) {
+            postSPTrips.push(score);
+          } else {
+            preSPTrips.push(score);
+          }
+        });
+
+        // Pre-star-pass points and lap scores go to starting jammer
+        var startPoints = 0;
+        preSPTrips.forEach(function (p) { startPoints += p; });
+
+        // Post-star-pass points go to the star pass recipient
+        var spPoints = 0;
+        postSPTrips.forEach(function (p) { spPoints += p; });
+
+        // If jamScore is nonzero but no scoring trips found, attribute all to starting jammer
+        if (jamScore > 0 && preSPTrips.length === 0 && postSPTrips.length === 0) {
+          startPoints = jamScore;
+        }
+
+        // Update starting jammer
+        var jam1 = ensureJammer(teamNum, startRef, startInfo);
+        jam1.jamsTotal++;
+        jam1.jamsStarted++;
+        jam1.totalScore += startPoints;
+        if (startPoints > 0) {
+          preSPTrips.forEach(function (p) { jam1.lapScores.push(p); });
+        }
+        if (isLead) jam1.leadCount++;
+
+        // Handle star pass recipient
+        if (starPass && jammerRefs.length > 1) {
+          var spRef = jammerRefs[1];
+          var spInfo = resolveSkater(spRef, skaterMap);
+          var jam2 = ensureJammer(teamNum, spRef, spInfo);
+          jam2.jamsTotal++;
+          jam2.jamsSP++;
+          jam2.totalScore += spPoints;
+          if (spPoints > 0) {
+            postSPTrips.forEach(function (p) { jam2.lapScores.push(p); });
+          }
+          // Star pass recipient cannot be lead
+        }
+
+        // If no fielding entries at all but jamScore > 0, attribute to unknown
+        if (jamScore > 0 && jammerRefs.length === 0) {
+          // Can't attribute — skip
+        }
+      });
+    });
+
+    // Compute derived stats
+    var jammerList = [];
+    Object.keys(jammers).forEach(function (k) { jammerList.push(jammers[k]); });
+
+    jammerList.forEach(function (j) {
+      j.ppj = j.jamsTotal > 0 ? (j.totalScore / j.jamsTotal) : 0;
+      j.leadPct = j.jamsTotal > 0 ? (j.leadCount / j.jamsTotal * 100) : 0;
+    });
+
+    // Sort by team then by total score descending
+    jammerList.sort(function (a, b) {
+      if (a.teamNum !== b.teamNum) return a.teamNum - b.teamNum;
+      return b.totalScore - a.totalScore;
+    });
+
+    return {
+      jammers: jammerList,
+      teamStats: teamStats,
+      totalJams: totalJamsCount
+    };
+  }
+
+  /* ═══════════════════════════════════════════
+   *  Render Functions
+   * ═══════════════════════════════════════════ */
+
+  function renderGameStats(stats) {
+    var el = document.getElementById('game-stats');
+    if (!el) return;
+
+    var ts1 = stats.teamStats['1'];
+    var ts2 = stats.teamStats['2'];
+    var totalJams = stats.totalJams || 1;
+
+    var leadPct1 = totalJams > 0 ? (ts1.leadCount / totalJams * 100).toFixed(0) : '0';
+    var leadPct2 = totalJams > 0 ? (ts2.leadCount / totalJams * 100).toFixed(0) : '0';
+
+    var ppj1 = ts1.totalJams > 0 ? round1(ts1.totalScore / ts1.totalJams) : '0.0';
+    var ppj2 = ts2.totalJams > 0 ? round1(ts2.totalScore / ts2.totalJams) : '0.0';
+
+    var ratio = ts2.totalScore > 0
+      ? round1(ts1.totalScore / ts2.totalScore)
+      : (ts1.totalScore > 0 ? '∞' : '—');
+
+    el.innerHTML =
+      '<div class="gs-row">' +
+        '<div class="gs-stat"><span class="gs-label">Lead %</span><span class="gs-value">' + leadPct1 + '%</span><span class="gs-divider">|</span><span class="gs-value">' + leadPct2 + '%</span></div>' +
+        '<div class="gs-stat"><span class="gs-label">Lead</span><span class="gs-value">' + ts1.leadCount + '</span><span class="gs-divider">|</span><span class="gs-value">' + ts2.leadCount + '</span></div>' +
+        '<div class="gs-stat"><span class="gs-label">Score</span><span class="gs-value">' + ts1.totalScore + '</span><span class="gs-divider">:</span><span class="gs-value">' + ts2.totalScore + '</span></div>' +
+        '<div class="gs-stat"><span class="gs-label">PPJ</span><span class="gs-value">' + ppj1 + '</span><span class="gs-divider">|</span><span class="gs-value">' + ppj2 + '</span></div>' +
+        '<div class="gs-stat"><span class="gs-label">Ratio</span><span class="gs-value gs-ratio">' + ratio + '</span></div>' +
+      '</div>';
+  }
+
+  function renderJammerTable(teamNum, teamLabel, jammers, teamScore) {
+    var el = document.getElementById('jammer-table-' + teamNum);
+    if (!el) return;
+
+    var filtered = jammers.filter(function (j) { return j.teamNum === teamNum; });
+    if (filtered.length === 0) {
+      el.innerHTML = '<div class="empty-message">No jammer data yet</div>';
+      return;
+    }
+
+    var rows = '';
+    filtered.forEach(function (j) {
+      var spInd = '';
+      if (j.jamsSP > 0) {
+        spInd = ' <span class="sp-badge" title="Includes star-pass pickups">SP</span>';
+      }
+
+      // Build lap scores display
+      var lapStr = '';
+      if (j.lapScores.length > 0) {
+        lapStr = j.lapScores.map(function (s) { return s; }).join(', ');
+      } else {
+        lapStr = j.totalScore > 0 ? String(j.totalScore) : '—';
+      }
+
+      var teamPct = teamScore > 0
+        ? ((j.totalScore / teamScore) * 100).toFixed(1) + '%'
+        : '0.0%';
+
+      rows += '<tr>' +
+        '<td class="j-num">#' + escHtml(j.number) + '</td>' +
+        '<td class="j-name">' + escHtml(j.name) + spInd + '</td>' +
+        '<td class="j-laps">' + escHtml(lapStr) + '</td>' +
+        '<td class="j-val">' + j.jamsTotal + '</td>' +
+        '<td class="j-val">' + j.leadCount + '</td>' +
+        '<td class="j-val">' + (j.leadPct).toFixed(0) + '%' + '</td>' +
+        '<td class="j-val">' + j.totalScore + '</td>' +
+        '<td class="j-val">' + round1(j.ppj) + '</td>' +
+        '<td class="j-val">' + teamPct + '</td>' +
+      '</tr>';
+    });
+
+    el.innerHTML =
+      '<table class="jammer-table">' +
+        '<thead><tr>' +
+          '<th>#</th>' +
+          '<th>Name</th>' +
+          '<th>Lap Scores</th>' +
+          '<th title="Jams">J</th>' +
+          '<th title="Lead">L</th>' +
+          '<th title="Lead %">L%</th>' +
+          '<th title="Total">Tot</th>' +
+          '<th title="Points Per Jam">PPJ</th>' +
+          '<th title="% of Team Score">%T</th>' +
+        '</tr></thead>' +
+        '<tbody>' + rows + '</tbody>' +
+      '</table>';
+  }
+
+  function renderTeamName(teamNum) {
+    var el = document.getElementById('team-name-' + teamNum);
+    if (!el) return;
+    var altKey = PREFIX + '.Team(' + teamNum + ').AlternateName(operator)';
+    var nameKey = PREFIX + '.Team(' + teamNum + ').Name';
+    var name = WS.state[altKey] || WS.state[nameKey] || 'Team ' + teamNum;
+    el.textContent = name;
+  }
+
+  /* ═══════════════════════════════════════════
+   *  Master Render
+   * ═══════════════════════════════════════════ */
+
+  var _renderQueued = false;
+
+  function queueRender() {
+    if (_renderQueued) return;
+    _renderQueued = true;
+    if (typeof triggerBatchFunc !== 'undefined') {
+      triggerBatchFunc(function () {
+        _renderQueued = false;
+        fullRender();
+      });
+    } else {
+      setTimeout(function () {
+        _renderQueued = false;
+        fullRender();
+      }, 50);
+    }
+  }
+
+  function fullRender() {
+    var stats = computeAllStats();
+
+    // Update team names
+    [1, 2].forEach(function (num) { renderTeamName(num); });
+
+    // Update game stats header
+    renderGameStats(stats);
+
+    // Get team scores for percentage calculation
+    var team1Score = asNum(getPath('Team(1).Score'));
+    var team2Score = asNum(getPath('Team(2).Score'));
+
+    // Render per-team jammer tables
+    renderJammerTable(1, null, stats.jammers, team1Score);
+    renderJammerTable(2, null, stats.jammers, team2Score);
+  }
+
+  /* ═══════════════════════════════════════════
+   *  WS.Register Setup
+   * ═══════════════════════════════════════════ */
+
+  // Team names + scores
+  WS.Register([
+    PREFIX + '.Team(*).AlternateName(operator)',
+    PREFIX + '.Team(*).Name',
+    PREFIX + '.Team(*).Score'
+  ], queueRender);
+
+  // All TeamJam data — jams, points, lead, star pass, fielding, scoring trips
+  WS.Register([
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).JamScore',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).Lead',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).Lost',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).StarPass',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).Calloff',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).TotalScore',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).Fielding(*).Skater',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).ScoringTrip(*).Score',
+    PREFIX + '.Period(*).Jam(*).TeamJam(*).ScoringTrip(*).AfterSP'
+  ], queueRender);
+
+  // Skater lookups
+  WS.Register([
+    PREFIX + '.Team(*).Skater(*).Name',
+    PREFIX + '.Team(*).Skater(*).RosterNumber'
+  ], queueRender);
+
+  /* ── Initial Render ── */
+
+  WS.AfterLoad(function () {
+    document.body.classList.remove('preload');
+    fullRender();
+  });
+
+  // Expose for demo/cron integration
+  if (typeof window !== 'undefined') {
+    window._announcerJammersRender = fullRender;
+  }
+
+})();

--- a/html/custom/view/announcer-jammers.css
+++ b/html/custom/view/announcer-jammers.css
@@ -1,0 +1,323 @@
+/* ═══════════════════════════════════════════
+ * Announcer Jammers View — Styles
+ *
+ * Dark theme with CSS custom properties.
+ * To restyle for game-day branding, change the
+ * values in :root — no need to touch selectors.
+ * ═══════════════════════════════════════════ */
+
+/* ── Theme Variables ── */
+:root {
+  /* Core background & text */
+  --bg-page: #0d1117;
+  --bg-card: #161b22;
+  --bg-card-alt: #1c2333;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #484f58;
+
+  /* Accent */
+  --accent: #58a6ff;
+  --accent-subtle: rgba(88, 166, 255, 0.15);
+  --border: #30363d;
+  --border-accent: #58a6ff;
+
+  /* Status */
+  --lead-color: #3fb950;
+  --lead-bg: rgba(63, 185, 80, 0.12);
+
+  /* Team colours (used when CRG scoreboard colours aren't available) */
+  --team1-bg: #1f6feb;
+  --team1-fg: #ffffff;
+  --team2-bg: #da3633;
+  --team2-fg: #ffffff;
+
+  /* Table */
+  --table-header-bg: #21262d;
+  --table-row-hover: #1c2128;
+  --table-border: #30363d;
+
+  /* Typography */
+  --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+  --font-mono: 'SFMono-Regular', 'Consolas', 'Liberation Mono', Menlo, monospace;
+  --font-size-base: 14px;
+  --font-size-sm: 12px;
+  --font-size-lg: 16px;
+  --font-size-xl: 20px;
+
+  /* Layout */
+  --gap: 16px;
+  --radius: 8px;
+  --radius-sm: 4px;
+}
+
+/* ── Reset ── */
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  background: var(--bg-page);
+  color: var(--text-primary);
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+body.preload * {
+  transition: none !important;
+}
+
+/* ── Connection Status ── */
+.connection-status {
+  text-align: center;
+  padding: 4px 8px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── Layout Container ── */
+.announcer-jammers {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--gap);
+}
+
+/* ═══════════════════════════════════════════
+ *  Game Stats Header
+ * ═══════════════════════════════════════════ */
+
+.game-stats-header {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 20px;
+  margin-bottom: var(--gap);
+}
+
+.gs-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.gs-stat {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--bg-card-alt);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.gs-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.gs-value {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  min-width: 28px;
+  text-align: center;
+}
+
+.gs-divider {
+  color: var(--text-muted);
+  font-weight: 300;
+  margin: 0 2px;
+}
+
+.gs-ratio {
+  color: var(--accent);
+}
+
+/* ═══════════════════════════════════════════
+ *  Team Section
+ * ═══════════════════════════════════════════ */
+
+.team-section {
+  margin-bottom: var(--gap);
+}
+
+.team-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius) var(--radius) 0 0;
+  border-bottom: none;
+}
+
+.team-header .team-name {
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+}
+
+.team-header .team-score-display {
+  font-size: var(--font-size-lg);
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  margin-left: auto;
+}
+
+.team-header .team-score-display strong {
+  color: var(--text-primary);
+  font-size: var(--font-size-xl);
+}
+
+.team-table-wrapper {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0 0 var(--radius) var(--radius);
+  overflow-x: auto;
+}
+
+/* ═══════════════════════════════════════════
+ *  Jammer Table
+ * ═══════════════════════════════════════════ */
+
+.jammer-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-base);
+}
+
+.jammer-table thead {
+  background: var(--table-header-bg);
+}
+
+.jammer-table thead th {
+  padding: 8px 10px;
+  text-align: left;
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--border);
+}
+
+.jammer-table thead th[title] {
+  cursor: help;
+}
+
+.jammer-table tbody tr {
+  border-bottom: 1px solid var(--table-border);
+  transition: background 0.15s ease;
+}
+
+.jammer-table tbody tr:hover {
+  background: var(--table-row-hover);
+}
+
+.jammer-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.jammer-table tbody td {
+  padding: 8px 10px;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+/* ── Column Styles ── */
+
+.j-num {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--accent);
+  width: 60px;
+}
+
+.j-name {
+  font-weight: 600;
+  min-width: 120px;
+}
+
+.j-laps {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.j-val {
+  font-family: var(--font-mono);
+  text-align: right;
+  min-width: 40px;
+}
+
+.jammer-table thead th.j-val {
+  text-align: right;
+}
+
+/* ── Star Pass Badge ── */
+.sp-badge {
+  display: inline-block;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-weight: 700;
+  background: var(--accent-subtle);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  margin-left: 4px;
+  vertical-align: middle;
+  line-height: 1.2;
+}
+
+/* ── Lead Highlight ── */
+.lead-highlight {
+  color: var(--lead-color);
+  font-weight: 700;
+}
+
+/* ── Empty State ── */
+.empty-message {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* ═══════════════════════════════════════════
+ *  Responsive
+ * ═══════════════════════════════════════════ */
+
+@media (max-width: 900px) {
+  .jammer-table {
+    font-size: var(--font-size-sm);
+  }
+  .jammer-table tbody td,
+  .jammer-table thead th {
+    padding: 6px 6px;
+  }
+  .j-laps {
+    max-width: 120px;
+  }
+  .gs-row {
+    gap: 12px;
+  }
+}

--- a/html/custom/view/announcer-jammers.html
+++ b/html/custom/view/announcer-jammers.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Announcer Jammers | CRG ScoreBoard</title>
+
+    <!--
+      Announcer Jammers View — Custom View for CRG ScoreBoard
+      Displays per-jammer performance stats for roller derby announcers:
+        - Per-jammer table: roster #, name, lap scores, jams, lead,
+          lead%, total score, PPJ, % of team score
+        - Game stats header: lead%, lead count, score, PPJ, ratio
+
+      Part of the SuspiciousOyster ScoreBoard custom views suite.
+      Licensed under the GNU General Public License v3 or later, or Apache 2.0.
+    -->
+
+    <script type="text/javascript" src="/external/jquery/jquery.js"></script>
+    <script type="text/javascript" src="/json/core.js"></script>
+
+    <link rel="stylesheet" href="announcer-jammers.css" type="text/css" />
+  </head>
+  <body class="preload">
+    <div class="announcer-jammers">
+
+      <!-- Connection Status -->
+      <div id="connection-status" class="connection-status">Connecting to ScoreBoard…</div>
+
+      <!-- Game Stats Header -->
+      <div id="game-stats" class="game-stats-header">
+        <div class="empty-message">Waiting for game data…</div>
+      </div>
+
+      <!-- Team 1 Section -->
+      <section class="team-section">
+        <div class="team-header" id="team-header-1">
+          <span class="team-name" id="team-name-1">Team 1</span>
+          <span class="team-score-display">Score: <strong id="team-score-1">0</strong></span>
+        </div>
+        <div class="team-table-wrapper">
+          <div id="jammer-table-1">
+            <div class="empty-message">Waiting for jammer data…</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Team 2 Section -->
+      <section class="team-section">
+        <div class="team-header" id="team-header-2">
+          <span class="team-name" id="team-name-2">Team 2</span>
+          <span class="team-score-display">Score: <strong id="team-score-2">0</strong></span>
+        </div>
+        <div class="team-table-wrapper">
+          <div id="jammer-table-2">
+            <div class="empty-message">Waiting for jammer data…</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <script type="text/javascript" src="announcer-jammers-render.js"></script>
+    <script type="text/javascript">
+      // Update team score displays in the header as they change
+      (function () {
+        'use strict';
+        var PREFIX = 'ScoreBoard.CurrentGame';
+        function updateTeamScores() {
+          var s1 = document.getElementById('team-score-1');
+          var s2 = document.getElementById('team-score-2');
+          if (s1) s1.textContent = parseInt(WS.state[PREFIX + '.Team(1).Score'] || '0', 10);
+          if (s2) s2.textContent = parseInt(WS.state[PREFIX + '.Team(2).Score'] || '0', 10);
+        }
+        WS.Register(PREFIX + '.Team(*).Score', updateTeamScores);
+        WS.AfterLoad(updateTeamScores);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What this adds

**Game-day custom view** (drops into any CRG ScoreBoard):
- `html/custom/view/announcer-jammers.html`
- `html/custom/view/announcer-jammers.css`
- `html/custom/view/announcer-jammers-render.js` (shared between real WS and demo)

**Demo assets** (standalone, no ScoreBoard needed):
- `demo/index.html` — landing page with Start button
- `demo/demo.html` — loads mock WS + shared render.js
- `demo/mock-ws.js` — scripted 12-jam game engine with star pass

**CI/CD:**
- `.github/workflows/demo-pages.yml` — deploys `demo/` to GitHub Pages

## What it shows

**Game stats header:** Lead %, Lead count, Score, PPJ, Ratio (both teams)

**Per-team jammer table:**
| # | Name | Lap Scores | Jams | Lead | L% | Tot | PPJ | %T |
|---|---|---|---|---|---|---|---|---|
| 420 | Bones | 4,3,1,5,2,2,1,5 | 8 | 5 | 62% | 31 | 3.9 | 67.9% |
| 99 | Blitz SP | 2 | 1 | 0 | 0% | 2 | 2.0 | 7.1% |

- Star pass recipients show `SP` badge
- No blockers listed — only skaters who've jammed

## Demo

Once merged, visit `https://suspiciousoyster.github.io/scoreboard/` → click Start → auto-playing game over ~55 seconds. All data computed from the same render.js that the real view uses.